### PR TITLE
Remove bootstrap as dependency

### DIFF
--- a/src/Preset.php
+++ b/src/Preset.php
@@ -19,9 +19,10 @@ class Preset extends LaravelPreset
     public static function updatePackageArray($packages)
     {
         return array_merge(['laravel-mix-tailwind' => '^0.1.0'], Arr::except($packages, [
-            'popper.js',
+            'bootstrap',
+            'jquery',
             'lodash',
-            'jquery'
+            'popper.js'
         ]));
     }
 


### PR DESCRIPTION
This pull request resolves #1 
I also sorted them from A-Z, as mentioned in the issue.