### PR TITLE
Changed file extension on app.sass to app.scss

### DIFF
--- a/src/Preset.php
+++ b/src/Preset.php
@@ -41,6 +41,6 @@ class Preset extends LaravelPreset
     {
         File::cleanDirectory(resource_path('assets/sass'));
 
-        File::put(resource_path('assets/sass/app.sass'), '');
+        File::put(resource_path('assets/sass/app.scss'), '');
     }
 }


### PR DESCRIPTION
`webpack.mix.js` is looking for `app.scss` but the `updateStyles()` function is creating a empty `app.sass`

Updated Preset.php to create an empty `app.scss` file.